### PR TITLE
Afegir els paquets "screen" i "molly-guard" al rol base

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -8,5 +8,7 @@
       - needrestart
       - aptitude
       - colordiff
+      - screen
+      - molly-guard
 - name: "fail2ban local jail"
   template: src=etc/fail2ban/jail.local.j2 dest=/etc/fail2ban/jail.local mode=0644 owner=root group=root


### PR DESCRIPTION
Tant el molly-guard com l'screen són paquets que fem servir a totes les màquines virtuals, per tant considero interessant instal·lar-los des de bon principi.